### PR TITLE
Add support for Singularity 2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Below are parameter defaults in Hiera format:
     singularity::mount_proc: yes
     singularity::mount_sys: yes
     singularity::mount_dev: yes
+    singularity::mount_devpts: yes
     singularity::mount_home: yes
     singularity::mount_tmp: yes
     singularity::mount_hostfs: no
@@ -71,6 +72,11 @@ Below are parameter defaults in Hiera format:
     singularity::sessiondir_max_size: 16
     #singularity::limit_container_owners: undef
     #singularity::limit_container_paths: undef
+    singularity::allow_containers:
+      squashfs: yes
+      extfs: yes
+      dir: yes
+    #singularity::autofs_bug_paths: undef
 
 #####`package_ensure`
 Package ensure parameter, defaults to `present`

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,16 +14,23 @@ class singularity (
   Enum['yes','no'] $mount_proc = 'yes',
   Enum['yes','no'] $mount_sys = 'yes',
   Enum['yes','no'] $mount_dev = 'yes',
+  Enum['yes','no'] $mount_devpts = 'yes',
   Enum['yes','no'] $mount_home = 'yes',
   Enum['yes','no'] $mount_tmp = 'yes',
   Enum['yes','no'] $mount_hostfs = 'no',
   Array $bind_paths = ['/etc/localtime', '/etc/hosts'],
   Enum['yes','no'] $user_bind_control = 'yes',
-  Enum['yes','no'] $enable_overlay = $singularity::params::enable_overlay,
+  Enum['yes','no','try'] $enable_overlay = $singularity::params::enable_overlay,
   Enum['yes','no'] $mount_slave = 'yes',
   Integer $sessiondir_max_size = 16,
   Optional[Array] $limit_container_owners = undef,
   Optional[Array] $limit_container_paths = undef,
+  Hash[String,Enum['yes','no']] $allow_containers = {
+    'squashfs' => 'yes',
+    'extfs' => 'yes',
+    'dir' => 'yes',
+  },
+  Optional[Array] $autofs_bug_paths = undef,
 ) inherits singularity::params {
 
   contain singularity::install

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -63,6 +63,7 @@ describe 'singularity' do
             'mount proc = yes',
             'mount sys = yes',
             'mount dev = yes',
+            'mount devpts = yes',
             'mount home = yes',
             'mount tmp = yes',
             'mount hostfs = no',
@@ -72,7 +73,9 @@ describe 'singularity' do
             "enable overlay = #{enable_overlay}",
             'mount slave = yes',
             'sessiondir max size = 16',
-            
+            'allow container squashfs = yes',
+            'allow container extfs = yes',
+            'allow container dir = yes',
           ])
         end
       end

--- a/templates/singularity.conf.erb
+++ b/templates/singularity.conf.erb
@@ -73,6 +73,15 @@ mount sys = <%= scope['singularity::mount_sys'] %>
 mount dev = <%= scope['singularity::mount_dev'] %>
 
 
+# MOUNT DEVPTS: [BOOL]
+# DEFAULT: yes
+# Should we mount a new instance of devpts if there is a 'minimal'
+# /dev, or -C is passed?  Note, this requires that your kernel was
+# configured with CONFIG_DEVPTS_MULTIPLE_INSTANCES=y, or that you're
+# running kernel 4.7 or newer.
+mount devpts = yes
+
+
 # MOUNT HOME: [BOOL]
 # DEFAULT: yes
 # Should we automatically determine the calling user's home directory and
@@ -121,10 +130,11 @@ bind path = <%= bind_path %>
 user bind control = <%= scope['singularity::user_bind_control'] %>
 
 
-# ENABLE OVERLAY: [BOOL]
+# ENABLE OVERLAY: [yes/no/try]
 # DEFAULT: yes
 # Enabling this option will make it possible to specify bind paths to locations
-# that do not currently exist within the container.
+# that do not currently exist within the container.  If 'try' is chosen,
+# overlayfs will be tried but if it is unavailable it will be silently ignored.
 enable overlay = <%= scope['singularity::enable_overlay'] %>
 
 
@@ -166,4 +176,26 @@ limit container owners = <%= scope['singularity::limit_container_owners'].join('
 #limit container paths = /scratch, /tmp, /global
 <%- if scope['singularity::limit_container_paths'] -%>
 limit container paths = <%= scope['singularity::limit_container_paths'].join(', ') %>
+<%- end -%>
+
+
+# ALLOW CONTAINER ${TYPE}: [BOOL]
+# DEFAULT: yes
+# This feature limits what kind of containers that Singularity will allow
+# users to use (note this does not apply for root).
+<%- scope['singularity::allow_containers'].each_pair do |type, value| -%>
+allow container <%= type %> = <%= value %>
+<%- end -%>
+
+
+# AUTOFS BUG PATH: [STRING]
+# DEFAULT: Undefined
+# Define list of autofs directories which produces "Too many levels of symbolink links"
+# errors when accessed from container (typically bind mounts)
+#autofs bug path = /nfs
+#autofs bug path = /cifs-share
+<%- if scope['singularity::autofs_bug_paths'] -%>
+<%- scope['singularity::autofs_bug_paths'].each do |autofs_bug_path| -%>
+autofs bug path = <%= autofs_bug_path %>
+<%- end -%>
 <%- end -%>


### PR DESCRIPTION
Add mount_devpts parameter, default to "yes"
Allow enable_overlay to also have value "try"
Add allow_containers parameter and default to {'squashfs': 'yes', 'extfs': 'yes', 'dir': 'yes'}
Add autofs_bug_paths parameter and default to undef