### PR TITLE
Fixed boolean error when using provided hiera parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,32 +50,32 @@ Below are parameter defaults in Hiera format:
     singularity::manage_epel: true
     singularity::config_path: /etc/singularity/singularity.conf
     singularity::config_template: singularity/singularity.conf.erb
-    singularity::allow_setuid: yes
+    singularity::allow_setuid: 'yes'
     singularity::max_loop_devices: 256
-    singularity::allow_pid_ns: yes
-    singularity::config_passwd: yes
-    singularity::config_group: yes
-    singularity::config_resolv_conf: yes
-    singularity::mount_proc: yes
-    singularity::mount_sys: yes
-    singularity::mount_dev: yes
-    singularity::mount_devpts: yes
-    singularity::mount_home: yes
-    singularity::mount_tmp: yes
-    singularity::mount_hostfs: no
+    singularity::allow_pid_ns: 'yes'
+    singularity::config_passwd: 'yes'
+    singularity::config_group: 'yes'
+    singularity::config_resolv_conf: 'yes'
+    singularity::mount_proc: 'yes'
+    singularity::mount_sys: 'yes'
+    singularity::mount_dev: 'yes'
+    singularity::mount_devpts: 'yes'
+    singularity::mount_home: 'yes'
+    singularity::mount_tmp: 'yes'
+    singularity::mount_hostfs: 'no'
     singularity::bind_paths:
       - /etc/localtime
       - /etc/hosts
-    singularity::user_bind_control: yes
-    singularity::enable_overlay: try
-    singularity::mount_slave: yes
+    singularity::user_bind_control: 'yes'
+    singularity::enable_overlay: 'try'
+    singularity::mount_slave: 'yes'
     singularity::sessiondir_max_size: 16
     #singularity::limit_container_owners: undef
     #singularity::limit_container_paths: undef
     singularity::allow_containers:
-      squashfs: yes
-      extfs: yes
-      dir: yes
+      squashfs: 'yes'
+      extfs: 'yes'
+      dir: 'yes'
     #singularity::autofs_bug_paths: undef
 
 ##### `package_ensure`

--- a/README.md
+++ b/README.md
@@ -44,39 +44,40 @@ Install and configure singularity:
 #### singularity
 
 Below are parameter defaults in Hiera format:
-
-    singularity::package_ensure: present
-    singularity::package_name: singularity
-    singularity::manage_epel: true
-    singularity::config_path: /etc/singularity/singularity.conf
-    singularity::config_template: singularity/singularity.conf.erb
-    singularity::allow_setuid: 'yes'
-    singularity::max_loop_devices: 256
-    singularity::allow_pid_ns: 'yes'
-    singularity::config_passwd: 'yes'
-    singularity::config_group: 'yes'
-    singularity::config_resolv_conf: 'yes'
-    singularity::mount_proc: 'yes'
-    singularity::mount_sys: 'yes'
-    singularity::mount_dev: 'yes'
-    singularity::mount_devpts: 'yes'
-    singularity::mount_home: 'yes'
-    singularity::mount_tmp: 'yes'
-    singularity::mount_hostfs: 'no'
-    singularity::bind_paths:
-      - /etc/localtime
-      - /etc/hosts
-    singularity::user_bind_control: 'yes'
-    singularity::enable_overlay: 'try'
-    singularity::mount_slave: 'yes'
-    singularity::sessiondir_max_size: 16
-    #singularity::limit_container_owners: undef
-    #singularity::limit_container_paths: undef
-    singularity::allow_containers:
-      squashfs: 'yes'
-      extfs: 'yes'
-      dir: 'yes'
-    #singularity::autofs_bug_paths: undef
+```yaml
+singularity::package_ensure: present
+singularity::package_name: singularity
+singularity::manage_epel: true
+singularity::config_path: /etc/singularity/singularity.conf
+singularity::config_template: singularity/singularity.conf.erb
+singularity::allow_setuid: 'yes'
+singularity::max_loop_devices: 256
+singularity::allow_pid_ns: 'yes'
+singularity::config_passwd: 'yes'
+singularity::config_group: 'yes'
+singularity::config_resolv_conf: 'yes'
+singularity::mount_proc: 'yes'
+singularity::mount_sys: 'yes'
+singularity::mount_dev: 'yes'
+singularity::mount_devpts: 'yes'
+singularity::mount_home: 'yes'
+singularity::mount_tmp: 'yes'
+singularity::mount_hostfs: 'no'
+singularity::bind_paths:
+  - /etc/localtime
+  - /etc/hosts
+singularity::user_bind_control: 'yes'
+singularity::enable_overlay: 'try'
+singularity::mount_slave: 'yes'
+singularity::sessiondir_max_size: 16
+#singularity::limit_container_owners: undef
+#singularity::limit_container_paths: undef
+singularity::allow_containers:
+  squashfs: 'yes'
+  extfs: 'yes'
+  dir: 'yes'
+#singularity::autofs_bug_paths: undef
+```
 
 ##### `package_ensure`
 


### PR DESCRIPTION
Since YAML interprets values such as `yes|no|on|off` as booleans, puppet will complain when using the hiera parameters as provided in the README:
```bash
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, Class[Singularity]:
  parameter 'allow_setuid' expects a match for Enum['no', 'yes'], got Boolean
  parameter 'allow_pid_ns' expects a match for Enum['no', 'yes'], got Boolean
...
```
As such it is important to make sure that these values are passed as strings instead.

This PR fixes the hiera parameter examples in the readme and enables YAML syntax highlighting to spot such issues in advance.