### PR TITLE
Bump upper version limit for the stdlib dependency

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,12 +1,14 @@
+# This file can be used to install module dependencies for unit testing
+# See https://github.com/puppetlabs/puppetlabs_spec_helper#using-fixtures for details
+---
 fixtures:
-  repositories:
+  forge_modules:
     stdlib:
-      repo: https://github.com/puppetlabs/puppetlabs-stdlib.git
-      ref: 4.13.1
+      repo: "puppetlabs/stdlib"
     epel:
-      repo: https://github.com/stahnma/puppet-module-epel.git
+      repo: "puppet/epel"
     yumrepo_core:
-      repo: https://github.com/puppetlabs/puppetlabs-yumrepo_core.git
+      repo: "puppetlabs/yumrepo_core"
       puppet_version: ">= 6.0.0"
   symlinks:
     singularity: "#{source_dir}"

--- a/metadata.json
+++ b/metadata.json
@@ -10,11 +10,11 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 <5.0.0"
+      "version_requirement": ">= 4.13.1 <9.0.0"
     },
     {
-      "name": "stahnma/epel",
-      "version_requirement": ">= 1.0.0 <2.0.0"
+      "name": "puppet/epel",
+      "version_requirement": ">= 3.0.0 <4.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
The metadata of the module still ponted to the old stahnma release
of the epel module. Change this to the puppet/epel the successor.
In addition rework fixture file to use forge release when running
rspec-puppet tests.
