### PR TITLE
Bump upper version limit for the stdlib dependency

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,20 +1,19 @@
+# This file can be used to install module dependencies for unit testing
+# See https://github.com/puppetlabs/puppetlabs_spec_helper#using-fixtures for details
+---
 fixtures:
-  repositories:
+  forge_modules:
     stdlib:
-      repo: https://github.com/puppetlabs/puppetlabs-stdlib.git
-      ref: 4.13.1
+      repo: "puppetlabs/stdlib"
     epel:
-      repo: https://github.com/voxpupuli/puppet-epel.git
-      ref: v3.0.0
+      repo: "puppet/epel"
     yumrepo_core:
-      repo: https://github.com/puppetlabs/puppetlabs-yumrepo_core.git
+      repo: "puppetlabs/yumrepo_core"
       puppet_version: ">= 6.0.0"
     golang:
-      repo: https://github.com/treydock/puppet-module-golang.git
-      ref: v1.0.0
+      repo: "treydock/golang"
     # Needed for golang
     archive:
-      repo: https://github.com/voxpupuli/puppet-archive.git
-      ref: v1.0.0
+      repo: "puppet/archive"
   symlinks:
     singularity: "#{source_dir}"

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 <8.0.0"
+      "version_requirement": ">= 4.13.1 <9.0.0"
     },
     {
       "name": "puppetlabs/yumrepo_core",


### PR DESCRIPTION
In addition reworked the fixture file to use forge releases when
running rspec-puppet and acceptance tests.
