### PR TITLE
Adding ldconfig.

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -94,6 +94,7 @@ The following parameters are available in the `singularity` class:
 * [`mksquashfs_procs`](#mksquashfs_procs)
 * [`mksquashfs_mem`](#mksquashfs_mem)
 * [`cryptsetup_path`](#cryptsetup_path)
+* [`ldconfig_path`](#ldconfig_path)
 * [`shared_loop_devices`](#shared_loop_devices)
 * [`image_driver`](#image_driver)
 * [`namespace_users`](#namespace_users)
@@ -565,6 +566,14 @@ Default value: ``undef``
 Data type: `Optional[Stdlib::Absolutepath]`
 
 See singularity.conf: `cryptsetup path`
+
+Default value: ``undef``
+
+##### <a name="ldconfig_path"></a>`ldconfig_path`
+
+Data type: `Optional[Stdlib::Absolutepath]`
+
+See singularity.conf: `ldconfig path`
 
 Default value: ``undef``
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -129,6 +129,8 @@
 #   See singularity.conf: `mksquashfs mem`
 # @param cryptsetup_path
 #   See singularity.conf: `cryptsetup path`
+# @param ldconfig_path
+#   See singularity.conf: `ldconfig path`
 # @param shared_loop_devices
 #   See singularity.conf: `shared loop devices`
 # @param image_driver
@@ -208,6 +210,7 @@ class singularity (
   Integer[0,default] $mksquashfs_procs = 0,
   Optional[String[1]] $mksquashfs_mem = undef,
   Optional[Stdlib::Absolutepath] $cryptsetup_path = undef,
+  Optional[Stdlib::Absolutepath] $ldconfig_path = undef,
   Enum['yes','no'] $shared_loop_devices = 'no',
   Optional[String] $image_driver = undef,
   Array $namespace_users = [],

--- a/templates/singularity.conf.erb
+++ b/templates/singularity.conf.erb
@@ -343,3 +343,12 @@ image driver = <%= scope['singularity::image_driver'] %>
 <%- else -%>
 image driver = 
 <%- end -%>
+
+# LDCONFIG PATH: [STRING]
+# DEFAULT: Undefined
+# Path to the ldconfig executable, used to find GPU libraries.
+# Must be set to use --nv / --nvccli.
+# Executable must be owned by root for security reasons.
+<%- if scope['singularity::ldconfig_path'] -%>
+ldconfig path = <%= scope['singularity::ldconfig_path'] %>
+<%- end -%>


### PR DESCRIPTION
The newer versions of singularity-ce require ldconfig path to be set to use --nv.  This should allow it to be set or not set depending on version and need.  See also: https://github.com/sylabs/singularity/issues/178  As well as the current documentation for singularity-ce 3.11:

```
# LDCONFIG PATH: [STRING]
# DEFAULT: Undefined
# Path to the ldconfig executable, used to find GPU libraries.
# Must be set to use --nv / --nvccli.
# Executable must be owned by root for security reasons.
```